### PR TITLE
Update types to add iconSize property

### DIFF
--- a/react-favicon.d.ts
+++ b/react-favicon.d.ts
@@ -9,6 +9,7 @@ export interface FaviconProps {
   readonly animationDelay?: number;
   readonly keepIconLink?: () => boolean;
   readonly renderOverlay?: (canvas: HTMLCanvasElement, context: CanvasRenderingContext2D) => void;
+  readonly iconSize?: number;
 }
 
 export default class Favicon extends React.Component<FaviconProps> {}


### PR DESCRIPTION
Update the types to match the changes introduced into: https://github.com/oflisback/react-favicon/pull/32